### PR TITLE
Fix orderBy parameter format in documentation

### DIFF
--- a/docs/source/Resources/Analysis/index.rst
+++ b/docs/source/Resources/Analysis/index.rst
@@ -22,7 +22,7 @@ Retrieves a list with all analyses from the account
                 "fields": ["id", "name"],
                 "filter": {},
                 "amount": 20,
-                "orderBy": "name,asc",
+                "orderBy": ["name","asc"],
             }
 
     **Returns:**

--- a/docs/source/Resources/Devices/index.rst
+++ b/docs/source/Resources/Devices/index.rst
@@ -106,8 +106,8 @@ Retrieves a list with all devices from the account
             "fields": ["id", "name"],
             "filter": {},
             "amount": 20,
-            "orderBy": "name,asc",
-            "resolveBucketName": false
+            "orderBy": ["name", "asc"],
+            "resolveBucketName": False
         }
 
 =========
@@ -204,7 +204,7 @@ Retrieves a list of all tokens
             "fields": ["name", "token", "permission"],
             "filter": {},
             "amount": 20,
-            "orderBy": "created_at,desc",
+            "orderBy": ["created_at", "desc"],
         }
 
 ==============

--- a/docs/source/common/Common_Type.rst
+++ b/docs/source/common/Common_Type.rst
@@ -204,5 +204,5 @@ Query
                 "fields": ["id", "name"],
                 "filter": {"name": "test"},
                 "amount": 20,
-                "orderBy": ["name": "asc"]
+                "orderBy": ["name", "asc"]
             }

--- a/src/tagoio_sdk/common/Common_Type.py
+++ b/src/tagoio_sdk/common/Common_Type.py
@@ -163,7 +163,7 @@ class Query(TypedDict):
             "fields": ["id", "name"],
             "filter": {"name": "test"},
             "amount": 20,
-            "orderBy": ["name": "asc"]
+            "orderBy": ["name", "asc"]
         }
     ```
     """

--- a/src/tagoio_sdk/modules/Resources/Analyses.py
+++ b/src/tagoio_sdk/modules/Resources/Analyses.py
@@ -28,7 +28,7 @@ class Analyses(TagoIOModule):
                 "fields": ["id", "name"],
                 "filter": {},
                 "amount": 20,
-                "orderBy": "name,asc",
+                "orderBy": ["name", "asc"],
             }
 
         :param AnalysisQuery queryObj: Search query params

--- a/src/tagoio_sdk/modules/Resources/Dashboards.py
+++ b/src/tagoio_sdk/modules/Resources/Dashboards.py
@@ -26,7 +26,7 @@ class Dashboards(TagoIOModule):
                 "fields": ["id", "name"],
                 "filter": {},
                 "amount": 20,
-                "orderBy": "label,asc",
+                "orderBy": ["label", "asc"],
             }
 
         :param queryObj Search query params

--- a/src/tagoio_sdk/modules/Resources/Devices.py
+++ b/src/tagoio_sdk/modules/Resources/Devices.py
@@ -35,8 +35,8 @@ class Devices(TagoIOModule):
                 "fields": ["id", "name"],
                 "filter": {},
                 "amount": 20,
-                "orderBy": "name,asc",
-                "resolveBucketName": false
+                "orderBy": ["name", "asc"],
+                "resolveBucketName": False
             }
 
         :param DeviceQuery queryObj: Search query params
@@ -232,7 +232,7 @@ class Devices(TagoIOModule):
                 "fields": ["name", "token", "permission"],
                 "filter": {},
                 "amount": 20,
-                "orderBy": "created_at,desc",
+                "orderBy": ["created_at", "desc"],
             }
 
         :param GenericID deviceID: Device ID


### PR DESCRIPTION
## Problem
Documentation examples contained invalid parameter formats that would cause runtime errors when copied by users. Issue #38 reported that `orderBy` parameter examples used incorrect string format instead of list format, and JavaScript `false` instead of Python `False`.

## Investigation
- Documentation showed `orderBy: "name,asc"` but API expects `["name", "asc"]` format
- Examples used `false` (JavaScript) instead of `False` (Python)
- Affected multiple modules: Analyses, Devices, Dashboards
- Both code examples and RST documentation had inconsistent formats

## Solution
- Updated all `orderBy` examples to use proper list format `["field", "direction"]`
- Replaced `false` with `False` in Python boolean examples
- Standardized parameter formats across documentation and code examples
- Fixed examples in Common_Type.py, all Resources modules, and RST documentation

Fixes #38