### PR TITLE
Added Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
         name: "Deploy package to PyPI"
         runs-on: ubuntu-latest
         needs: [build]
+        permissions:
+            id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
         steps:
             - uses: actions/checkout@v4
@@ -55,9 +57,7 @@ jobs:
               run: uv build
 
             - name: Publish to PyPI
-              env:
-                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-              run: uv publish --token $PYPI_TOKEN
+              uses: pypa/gh-action-pypi-publish@release/v1
 
     docs:
         name: "Deploy Docs"


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to improve the workflow for publishing packages to PyPI. The changes include adding mandatory permissions for trusted publishing and switching to a standardized GitHub Action for PyPI publishing.

### Updates to the PyPI publishing workflow:

* Added `id-token: write` permission under `permissions` in the "Deploy package to PyPI" job to enable trusted publishing.
* Replaced manual token-based publishing with the `pypa/gh-action-pypi-publish` GitHub Action for streamlined package deployment.