### PR TITLE
fix/send-downlink-utils

### DIFF
--- a/src/tagoio_sdk/modules/Resources/Devices.py
+++ b/src/tagoio_sdk/modules/Resources/Devices.py
@@ -263,7 +263,7 @@ class Devices(TagoIOModule):
             }
         )
         result = dateParserList(
-            result, ["created_at", "last_authorization", "expire_time"]
+            result, ["created_at", "expire_time"]
         )
 
         return result

--- a/src/tagoio_sdk/modules/Utils/sendDownlink.py
+++ b/src/tagoio_sdk/modules/Utils/sendDownlink.py
@@ -1,4 +1,5 @@
 import json
+
 from typing import Union
 
 import requests

--- a/src/tagoio_sdk/modules/Utils/sendDownlink.py
+++ b/src/tagoio_sdk/modules/Utils/sendDownlink.py
@@ -1,3 +1,4 @@
+import json
 from typing import Union
 
 import requests
@@ -104,7 +105,7 @@ def sendDownlink(
     """
     if not isinstance(resource, Account) and not isinstance(resource, Resources):
         raise TypeError(
-            "The parameter 'account' must be an instance of a TagoIO Resources."
+            "The parameter 'resource' must be an instance of a TagoIO Resources."
         )
 
     token = getDeviceToken(resource=resource, device_id=device_id)
@@ -128,7 +129,14 @@ def sendDownlink(
         "port": dn_options["port"],
     }
 
-    result = requests.post(f"https://{middleware_endpoint}/downlink", data)
+    if dn_options.get("confirmed") is not None:
+        data.update({"confirmed": dn_options["confirmed"]})
+
+    result = requests.post(
+        url=f"https://{middleware_endpoint}/downlink",
+        data=json.dumps(data),
+        headers={"Content-Type": "application/json"},
+    )
 
     if result.status_code in range(400, 500):
         raise TypeError(


### PR DESCRIPTION
## What does PR do?

This PR fixes critical issues in the `sendDownlink` utility function and improves device data parsing:

- Corrects error message parameter reference from 'account' to 'resource' for accuracy
- Adds proper JSON encoding for downlink POST requests with Content-Type header
- Implements support for optional 'confirmed' parameter in downlink options
- Removed the unnecessary `last_authorization` field from the device data parser, which was causing the following error:
```bash
An error occurred: Unknown string format: ate42e30efb2bb4ca7xxxxxxxxxxxxxxxx
```

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update