### PR TITLE
realease/5.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tagoio-sdk"
-version = "5.1.0"
+version = "5.1.1"
 description = "Official Python SDK for TagoIO"
 authors = [{name = "TagoIO Inc.", email = "contact@tago.io"}]
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "tagoio-sdk"
-version = "5.1.0"
+version = "5.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
## What does PR do?

This PR bumps the TagoIO Python SDK version from 5.1.0 to 5.1.1.

### Version Update

- Updated version in [pyproject.toml](pyproject.toml) from `5.1.0` to `5.1.1`
- Updated corresponding version in [uv.lock](uv.lock)