### PR TITLE
Deprecate services.mqtt.publish()

### DIFF
--- a/docs/source/Services/MQTT_Type.rst
+++ b/docs/source/Services/MQTT_Type.rst
@@ -2,9 +2,7 @@
 ===============
 
 .. deprecated::
-    Legacy MQTT is deprecated and will be removed in a future major version.
-    Migrate to the new MQTT connector or use the HTTP API.
-    See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+    Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt
 
 .. _mqtt_options:
 

--- a/docs/source/Services/MQTT_Type.rst
+++ b/docs/source/Services/MQTT_Type.rst
@@ -1,6 +1,11 @@
 **MQTT Type**
 ===============
 
+.. deprecated::
+    Legacy MQTT is deprecated and will be removed in a future major version.
+    Migrate to the new MQTT connector or use the HTTP API.
+    See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+
 .. _mqtt_options:
 
 options

--- a/docs/source/Services/index.rst
+++ b/docs/source/Services/index.rst
@@ -100,6 +100,11 @@ Send Email
 MQTT
 ====
 
+.. deprecated::
+    Legacy MQTT is deprecated and will be removed in a future major version.
+    Migrate to the new MQTT connector or use the HTTP API.
+    See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+
 Publish to a MQTT Device
 
     **Parameters:**

--- a/docs/source/Services/index.rst
+++ b/docs/source/Services/index.rst
@@ -101,9 +101,7 @@ MQTT
 ====
 
 .. deprecated::
-    Legacy MQTT is deprecated and will be removed in a future major version.
-    Migrate to the new MQTT connector or use the HTTP API.
-    See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+    Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt
 
 Publish to a MQTT Device
 

--- a/src/tagoio_sdk/modules/Services/MQTT.py
+++ b/src/tagoio_sdk/modules/Services/MQTT.py
@@ -25,13 +25,11 @@ class MQTT(TagoIOModule):
         """Publish an MQTT message.
 
         .. deprecated::
-            Legacy MQTT is deprecated. Use the new MQTT connector or HTTP API instead.
-            See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+            Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt
         """
         warnings.warn(
-            "services.mqtt.publish() is deprecated and will be removed in a future major version. "
-            "Migrate to the new MQTT connector or use the HTTP API. "
-            "See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/",
+            "services.mqtt.publish() is deprecated. "
+            "Migrate to TagoTIP: https://docs.tago.io/docs/tagotip/transports/mqtt",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/tagoio_sdk/modules/Services/MQTT.py
+++ b/src/tagoio_sdk/modules/Services/MQTT.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 from typing import TypedDict
 from typing import Union
@@ -20,6 +21,19 @@ class MQTTData(TypedDict):
 
 class MQTT(TagoIOModule):
     def publish(self, mqtt: MQTTData) -> str:
+        """Publish an MQTT message.
+
+        .. deprecated::
+            Legacy MQTT is deprecated. Use the new MQTT connector or HTTP API instead.
+            See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/
+        """
+        warnings.warn(
+            "services.mqtt.publish() is deprecated and will be removed in a future major version. "
+            "Migrate to the new MQTT connector or use the HTTP API. "
+            "See: https://docs.tago.io/docs/tagoio/integrations/networks/mqtt/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         result = self.doRequest(
             {
                 "path": "/analysis/services/mqtt/publish",

--- a/src/tagoio_sdk/modules/Services/MQTT.py
+++ b/src/tagoio_sdk/modules/Services/MQTT.py
@@ -1,4 +1,5 @@
 import warnings
+
 from typing import Optional
 from typing import TypedDict
 from typing import Union


### PR DESCRIPTION
## Summary

- Adds `warnings.warn(DeprecationWarning)` to `Services.MQTT.publish()`
- Adds a `.. deprecated::` directive in the method docstring
- Points users to the new MQTT connector and HTTP API as alternatives

Legacy MQTT is being phased out. This change gives SDK consumers a heads-up before the method is removed in a future major version.

## Test plan

- [ ] Calling `services.MQTT.publish()` emits a `DeprecationWarning`
- [ ] Existing functionality remains unchanged (the request still goes through)
- [ ] Warning includes migration link to docs