### PR TITLE
feature/run-type-options

### DIFF
--- a/docs/source/Resources/Analysis/Analysis_Type.rst
+++ b/docs/source/Resources/Analysis/Analysis_Type.rst
@@ -13,7 +13,7 @@ ScriptFile
 
         | content: :ref:`Base64`
 
-        | language: "node" or "python"
+        | language: :ref:`RunTypeOptions`
 
 
 
@@ -34,7 +34,7 @@ AnalysisCreateInfo
 
         | file_name: Optional[str]
 
-        | runtime: Optional["node" or "python"]
+        | runtime: Optional[:ref:`RunTypeOptions`]
 
         | active: Optional[bool]
 

--- a/docs/source/common/Common_Type.rst
+++ b/docs/source/common/Common_Type.rst
@@ -43,6 +43,13 @@ Conditionals
 
     | **Conditionals**: Literal["<", ">", "=", "!", "><", "*"]
 
+.. _RunTypeOptions:
+
+RunTypeOptions
+----------------
+
+    | **RunTypeOptions**: Literal["node-legacy", "python-legacy", "node-rt2025", "python-rt2025", "deno-rt2025"]
+
 .. _TokenCreateResponse:
 
 TokenCreateResponse

--- a/src/tagoio_sdk/common/Common_Type.py
+++ b/src/tagoio_sdk/common/Common_Type.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import TypedDict
 from typing import Union
 
+
 GenericID = str
 """ID used on TagoIO, string with 24 character"""
 

--- a/src/tagoio_sdk/common/Common_Type.py
+++ b/src/tagoio_sdk/common/Common_Type.py
@@ -4,7 +4,6 @@ from typing import Optional
 from typing import TypedDict
 from typing import Union
 
-
 GenericID = str
 """ID used on TagoIO, string with 24 character"""
 
@@ -19,6 +18,8 @@ ExpireTimeOption = Union[Literal["never"], datetime]
 PermissionOption = Literal["write", "read", "full", "deny"]
 
 Conditionals = Literal["<", ">", "=", "!", "><", "*"]
+
+RunTypeOptions = Literal["node-legacy", "python-legacy", "node-rt2025", "python-rt2025", "deno-rt2025"]
 
 
 class TokenCreateResponse(TypedDict):

--- a/src/tagoio_sdk/modules/Resources/Analyses.py
+++ b/src/tagoio_sdk/modules/Resources/Analyses.py
@@ -19,7 +19,6 @@ from tagoio_sdk.modules.Resources.Analysis_Types import SnippetsListResponse
 from tagoio_sdk.modules.Utils.dateParser import dateParser
 from tagoio_sdk.modules.Utils.dateParser import dateParserList
 
-
 # Base URL for TagoIO analysis snippets repository
 SNIPPETS_BASE_URL = "https://snippets.tago.io"
 
@@ -85,7 +84,7 @@ class Analyses(TagoIOModule):
             resources = Resources()
             new_analysis = resources.analyses.create({
                 "name": "My Analysis",
-                "runtime": "python",
+                "runtime": "python-rt2025",
                 "tags": [{"key": "type", "value": "data-processing"}]
             })
             print(new_analysis["id"], new_analysis["token"])  # analysis-id-123, analysis-token-123
@@ -268,7 +267,7 @@ class Analyses(TagoIOModule):
             result = resources.analyses.uploadScript("analysis-id-123", {
                 "name": "script.py",
                 "content": "base64-encoded-content",
-                "language": "python"
+                "language": "python-rt2025"
             })
             print(result)  # Successfully Uploaded
             ```

--- a/src/tagoio_sdk/modules/Resources/Analyses.py
+++ b/src/tagoio_sdk/modules/Resources/Analyses.py
@@ -19,6 +19,7 @@ from tagoio_sdk.modules.Resources.Analysis_Types import SnippetsListResponse
 from tagoio_sdk.modules.Utils.dateParser import dateParser
 from tagoio_sdk.modules.Utils.dateParser import dateParserList
 
+
 # Base URL for TagoIO analysis snippets repository
 SNIPPETS_BASE_URL = "https://snippets.tago.io"
 

--- a/src/tagoio_sdk/modules/Resources/Analysis_Types.py
+++ b/src/tagoio_sdk/modules/Resources/Analysis_Types.py
@@ -11,8 +11,8 @@ from tagoio_sdk.common.Common_Type import Base64
 from tagoio_sdk.common.Common_Type import ExpireTimeOption
 from tagoio_sdk.common.Common_Type import GenericID
 from tagoio_sdk.common.Common_Type import Query
-from tagoio_sdk.common.Common_Type import TagsObj
 from tagoio_sdk.common.Common_Type import RunTypeOptions
+from tagoio_sdk.common.Common_Type import TagsObj
 
 
 class ScriptFile(TypedDict):

--- a/src/tagoio_sdk/modules/Resources/Analysis_Types.py
+++ b/src/tagoio_sdk/modules/Resources/Analysis_Types.py
@@ -12,12 +12,13 @@ from tagoio_sdk.common.Common_Type import ExpireTimeOption
 from tagoio_sdk.common.Common_Type import GenericID
 from tagoio_sdk.common.Common_Type import Query
 from tagoio_sdk.common.Common_Type import TagsObj
+from tagoio_sdk.common.Common_Type import RunTypeOptions
 
 
 class ScriptFile(TypedDict):
     name: str
     content: Base64
-    language: Literal["node", "python"]
+    language: RunTypeOptions
 
 
 class AnalysisCreateInfo(TypedDict, total=False):
@@ -26,7 +27,7 @@ class AnalysisCreateInfo(TypedDict, total=False):
     interval: Optional[str]
     run_on: Optional[Literal["tago", "external"]]
     file_name: Optional[str]
-    runtime: Optional[Literal["node", "python"]]
+    runtime: Optional[RunTypeOptions]
     active: Optional[bool]
     profile: Optional[GenericID]
     variables: Optional[List[Dict[str, Union[str, int, bool]]]]
@@ -44,11 +45,7 @@ class AnalysisInfo(AnalysisCreateInfo):
 
 
 class AnalysisQuery(Query):
-    fields: Optional[
-        List[
-            Literal["name", "active", "run_on", "last_run", "created_at", "updated_at"]
-        ]
-    ]
+    fields: Optional[List[Literal["name", "active", "run_on", "last_run", "created_at", "updated_at"]]]
 
 
 class AnalysisListItem(TypedDict, total=False):
@@ -63,9 +60,7 @@ class AnalysisListItem(TypedDict, total=False):
     console: Optional[List[str]]
 
 
-SnippetRuntime = Literal[
-    "node-legacy", "python-legacy", "node-rt2025", "python-rt2025", "deno-rt2025"
-]
+SnippetRuntime = Literal["node-legacy", "python-legacy", "node-rt2025", "python-rt2025", "deno-rt2025"]
 """Available runtime environments for snippets"""
 
 


### PR DESCRIPTION
## What does PR do?

Adds a shared `RunTypeOptions` type to represent the supported analysis runtimes and applies it across the analysis modules, replacing the old `node`/`python`-only options.

### Core change

- **New shared type** `RunTypeOptions` in `Common_Type` covering all current runtimes: `node-legacy`, `python-legacy`, `node-rt2025`, `python-rt2025`, `deno-rt2025`
- **Analysis fields updated** so `ScriptFile.language` and `AnalysisCreateInfo.runtime` use the new type instead of the narrow `node`/`python` literals
- **Docstrings refreshed** to use the new runtime values (e.g. `python-rt2025`) in usage examples
- **Docs updated** to reference `RunTypeOptions` and expose the full list of supported values
