### PR TITLE
realease/5.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tagoio-sdk"
-version = "5.1.1"
+version = "5.1.2"
 description = "Official Python SDK for TagoIO"
 authors = [{name = "TagoIO Inc.", email = "contact@tago.io"}]
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "tagoio-sdk"
-version = "5.1.1"
+version = "5.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
## What does PR do?

This PR bumps the TagoIO Python SDK version from 5.1.1 to 5.1.2.

